### PR TITLE
Fix a couple of soundness bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ the map.
 
 ### Example
 ```rust
-use std::{cell::RefCell, ops::AddAssign};
+use std::{ops::AddAssign, sync::RwLock};
 
 use num_traits::{One, Zero};
 
-fn generic_call_counter<T: Zero + One + Copy + AddAssign + Send + 'static>() -> T {
-    let mut count = generic_singleton::get_or_init!(|| RefCell::new(T::zero())).borrow_mut();
+fn generic_call_counter<T: Zero + One + Copy + AddAssign + Send + Sync + 'static>() -> T {
+    let mut count = generic_singleton::get_or_init!(|| RwLock::new(T::zero())).write().unwrap();
     *count += T::one();
     *count
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@ pub mod thread_local_static_anymap;
 ///
 /// ### Example
 /// ```rust
-/// use std::cell::RefCell;
 /// use std::collections::HashMap;
 /// use std::ops::{Deref, DerefMut, Mul};
+/// use std::sync::RwLock;
 ///
 /// // The expensive function we're trying to cache using a singleton map, however,
 /// // we want the user of the function to determine the type of the elements being
@@ -29,17 +29,17 @@ pub mod thread_local_static_anymap;
 /// where
 ///     T: std::cmp::Eq,
 ///     T: Copy,
-///     T: 'static,
+///     T: Sync + 'static,
 ///     (T, T): std::hash::Hash,
 /// {
 ///     // This is a generic singleton map!!!
-///     let map = generic_singleton::get_or_init!(|| RefCell::new(HashMap::new()));
+///     let map = generic_singleton::get_or_init!(|| RwLock::new(HashMap::new()));
 ///     let key = (a, b);
-///     if map.borrow().contains_key(&key) {
-///         *map.borrow().get(&key).unwrap()
+///     if map.read().unwrap().contains_key(&key) {
+///         *map.read().unwrap().get(&key).unwrap()
 ///     } else {
 ///         let result = multiply(a, b);
-///         map.borrow_mut().insert(key, result);
+///         map.write().unwrap().insert(key, result);
 ///         result
 ///     }
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,11 +109,7 @@ macro_rules! get_or_init_thread_local {
     ($init:expr, $with:expr) => {{
         use $crate::thread_local_static_anymap::ThreadLocalStaticAnymap;
         thread_local!(static STATIC_ANY_MAP: ThreadLocalStaticAnymap = ThreadLocalStaticAnymap::default());
-
-        // SAFETY:
-        // The reference to the STATIC_ANY_MAP is contained within this macro soo the $init
-        // expression cannot possibly reference it.
-        STATIC_ANY_MAP.with(|map| unsafe { map.get_or_init_with($init, $with) })
+        STATIC_ANY_MAP.with(|map| map.get_or_init_with($init, $with))
     }};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,15 +106,14 @@ macro_rules! get_or_init {
 /// ```
 #[macro_export]
 macro_rules! get_or_init_thread_local {
-     ($init:expr, $with:expr) => {{
-         use $crate::thread_local_static_anymap::ThreadLocalStaticAnymap;
-         thread_local!(static STATIC_ANY_MAP: ThreadLocalStaticAnymap = ThreadLocalStaticAnymap::default());
-         // SAFETY:
-         // The reference to the STATIC_ANY_MAP is contained within this macro soo the $init
-         // expression cannot possibly reference it.
-         unsafe {STATIC_ANY_MAP.with(|map| {
-             map.get_or_init_with($init, $with)
-         })}
+    ($init:expr, $with:expr) => {{
+        use $crate::thread_local_static_anymap::ThreadLocalStaticAnymap;
+        thread_local!(static STATIC_ANY_MAP: ThreadLocalStaticAnymap = ThreadLocalStaticAnymap::default());
+
+        // SAFETY:
+        // The reference to the STATIC_ANY_MAP is contained within this macro soo the $init
+        // expression cannot possibly reference it.
+        STATIC_ANY_MAP.with(|map| unsafe { map.get_or_init_with($init, $with) })
     }};
 }
 

--- a/src/static_anymap.rs
+++ b/src/static_anymap.rs
@@ -87,3 +87,45 @@ unsafe fn convert_to_static_ref<T>(pin: &Pin<Box<T>>) -> &'static T {
     // from a valid reference, therefore this is considered safe to do.
     unsafe { optional_ref.unwrap_unchecked() }
 }
+
+// Compile tests
+
+// Note: compile_fail tests need to be in a public module that exists even when `cfg(not(test))`
+// otherwise the compiler won't execute them.
+
+/// ```compile_fail
+/// use generic_singleton::static_anymap::StaticAnyMap;
+///
+/// fn check_not_send() where StaticAnyMap: Send {}
+/// ```
+const _: () = ();
+
+#[allow(unused)]
+fn check_sync()
+where
+    StaticAnyMap: Sync,
+{
+}
+
+/// ```compile_fail
+/// use generic_singleton::static_anymap::StaticAnyMap;
+///
+/// fn check_t_needs_sync<T: Default + 'static>(map: &'static StaticAnyMap) {
+///     map.get_or_init::<T>(T::default);
+/// }
+/// ```
+const _: () = ();
+
+/// ```compile_fail
+/// use generic_singleton::static_anymap::StaticAnyMap;
+///
+/// fn check_t_needs_static<T: Default + Sync>(map: &'static StaticAnyMap) {
+///     map.get_or_init::<T>(T::default);
+/// }
+/// ```
+const _: () = ();
+
+#[allow(unused)]
+fn check_t_needs_sync_not_send<T: Default + Sync + 'static>(map: &'static StaticAnyMap) {
+    map.get_or_init::<T>(T::default);
+}

--- a/src/static_anymap.rs
+++ b/src/static_anymap.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use std::pin::Pin;
 
 use anymap::AnyMap;
@@ -10,6 +11,9 @@ use parking_lot::RwLock;
 #[derive(Default)]
 pub struct StaticAnyMap {
     inner: RwLock<AnyMap>,
+    /// This guarantees that `StaticAnyMap` remains `!Send` (even though `AnyMap` is already `!Send`),
+    /// which allows accessors to safely avoid requiring `T: Send`.
+    _phantom: PhantomData<*mut ()>,
 }
 
 // SAFETY:

--- a/src/static_anymap.rs
+++ b/src/static_anymap.rs
@@ -20,19 +20,10 @@ pub struct StaticAnyMap {
 // From the rustonomicon:
 // https://doc.rust-lang.org/nomicon/send-and-sync.html
 // "A type is Sync if it is safe to share between threads (T is Sync if and only if &T is Send)."
-// All accessors are only implemented for 'static references, so I believe we can say &T ('static
-// implied) is Send. And since any mutation is guarded by a RwLock, the type should be sync too.
-//
-// I'm a bit uncertain about the above. I've managed to limit access to the inner AnyMap via
-// 'static references, but there's nothing stopping a user from creating a non-'static
-// StaticAnyMap. The impl below allows to send it between threads, even if the type is not
-// 'static. This instance would be unusable but perhaps it can still trigger UB. For example in
-// the following podcast at ~14:10, Andrew Kelly mentions the existence of a dangling pointer
-// might cause undefined behaviour:
-// https://rustacean-station.org/episode/andrew-kelley/
-// I'm concerned that, similar to the dangling pointer example, the existence of a struct that is
-// shared across thread boundaries which shouldn't already triggers UB regardless of whether it's
-// actually accessed.
+// All accessors are only implemented for `T: Sync`, so we can say &T ('static implied) is Send.
+// Since we never return `&mut T` we can safely store `!Send` data as long as `StaticAnyMap`
+// remains `!Send` (which it currently is, though it would be nice to have a test for that).
+// Since any accessor implicitly requires `T: 'static` we can assume there's no dangling data.
 unsafe impl Sync for StaticAnyMap {}
 
 impl StaticAnyMap {

--- a/src/thread_local_static_anymap.rs
+++ b/src/thread_local_static_anymap.rs
@@ -22,7 +22,7 @@ impl ThreadLocalStaticAnymap {
     pub fn get_or_init_with<T: 'static>(
         &self,
         init: impl FnOnce() -> T,
-        mut with: impl FnMut(&mut T),
+        with: impl FnOnce(&mut T),
     ) {
         let optional_t: &UnsafeCell<Option<RefCell<T>>> = {
             // SAFETY:

--- a/src/thread_local_static_anymap.rs
+++ b/src/thread_local_static_anymap.rs
@@ -81,3 +81,36 @@ impl ThreadLocalStaticAnymap {
         with(&mut *t_ref.borrow_mut())
     }
 }
+
+// Compile tests
+
+// Note: compile_fail tests need to be in a public module that exists even when `cfg(not(test))`
+// otherwise the compiler won't execute them.
+
+/// ```compile_fail
+/// use generic_singleton::thread_local_static_anymap::ThreadLocalStaticAnymap;
+///
+/// fn check_not_send() where ThreadLocalStaticAnymap: Send {}
+/// ```
+const _: () = ();
+
+/// ```compile_fail
+/// use generic_singleton::thread_local_static_anymap::ThreadLocalStaticAnymap;
+///
+/// fn check_not_sync() where ThreadLocalStaticAnymap: Sync {}
+/// ```
+const _: () = ();
+
+/// ```compile_fail
+/// use generic_singleton::thread_local_static_anymap::ThreadLocalStaticAnymap;
+///
+/// fn check_t_needs_static<T: Default>(map: &'static ThreadLocalStaticAnymap) {
+///     map.get_or_init_with::<T>(T::default, |_| ());
+/// }
+/// ```
+const _: () = ();
+
+#[allow(unused)]
+fn check_t_needs_not_sync_not_send<T: Default + 'static>(map: &'static ThreadLocalStaticAnymap) {
+    map.get_or_init_with::<T>(T::default, |_| ());
+}


### PR DESCRIPTION
This PR fixes a couple of soundness bugs which could lead to UB in some situations. Here's an example of how some of them could be exploited:

```rust
// Show why giving a mutable reference to `with` is not ok
fn bad(first: bool, mut r1: Option<&mut i32>) {
    generic_singleton::get_or_init_thread_local!(|| 0, move |r2| {
        if first {
            bad(false, Some(r2))
        } else {
            println!("r1 = {:p}, r2 = {:?}", r1.as_mut().unwrap(), r2);
        }
    });
}
bad(true, None);

// Show why `get_or_init` should require `T: Sync`
std::thread::scope(|s| {
    for _ in 0..2 {
        s.spawn(|| {
            // Note that `Cell` is `!Sync`, but both `println` print the same address,
            // so we got two shared references to the same `!Sync` value in two different threads.
            // This is unsound
            let c = generic_singleton::get_or_init!(|| std::cell::Cell::new(0));
            println!("{:p}", c);
        });
    }
});

// Show why `get_or_init_thread_local`'s use of `unsafe` is wrong wrt hygiene.
// It allows `unsafe` operations in the given closures without needing to type `unsafe` outside.
generic_singleton::get_or_init_thread_local!(|| *std::ptr::null_mut::<i32>(), |_| ());
```

The solution for bug 1 is to use a `RefCell` in `ThreadLocalStaticAnymap::get_or_init_with`. A similar idea can be used with `init`, so it's required to not hold onto the inner `AnyMap` while `init`/`with` are being called, and that's the reason for the `UnsafeCell` dance.

The solution for bug 2 is to require `T: Sync` instead of `T: Send`. I also added explicit `T: 'static` annotations and a `PhantomData` field to guarantee the struct is `!Send`, although they are not really needed because both are already implied (the first by the `&'static T` return type, the second by the `AnyMap` which is `!Send`)

The solution for bug 3 comes for free with the fix for bug 1, since after that `unsafe` is no longer needed.