### PR TITLE
Replace `anymap` with `anymap3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anymap = "1.0.0-beta.2"
+anymap3 = "1.0.1"
 lazy_static = "1.4.0"
 parking_lot = "0.12.1"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(clippy::undocumented_unsafe_blocks)]
 #![deny(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
-pub extern crate anymap;
+extern crate anymap3;
 
 #[doc(hidden)]
 pub mod static_anymap;

--- a/src/static_anymap.rs
+++ b/src/static_anymap.rs
@@ -1,6 +1,6 @@
 use std::pin::Pin;
 
-use anymap::AnyMap;
+use anymap3::AnyMap;
 use parking_lot::RwLock;
 
 /// The point of this struct is to wrap the AnyMap in a concurrent, static version that will only

--- a/src/thread_local_static_anymap.rs
+++ b/src/thread_local_static_anymap.rs
@@ -1,4 +1,4 @@
-use anymap::AnyMap;
+use anymap3::AnyMap;
 use std::cell::UnsafeCell;
 
 /// The point of this struct is to wrap the AnyMap in a thread local, version that will only insert


### PR DESCRIPTION
`anymap` seems unmaintained, and now it doesn't build under Rust 1.87, with error E0804.

See https://github.com/chris-morgan/anymap/issues/53.